### PR TITLE
Integration of Github Updater Lite

### DIFF
--- a/github-updater.php
+++ b/github-updater.php
@@ -1,0 +1,156 @@
+<?php
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'GHU_Core' ) ) {
+    class GHU_Core
+    {
+        public $update_data = array();
+        public $active_plugins = array();
+
+
+        function __construct() {
+            add_action( 'admin_init', array( $this, 'admin_init' ) );
+            add_filter( 'plugins_api', array( $this, 'plugins_api' ), 10, 3 );
+            add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'set_update_data' ) );
+            add_filter( 'upgrader_source_selection', array( $this, 'upgrader_source_selection' ), 10, 4 );
+            add_filter( 'extra_plugin_headers', array( $this, 'extra_plugin_headers' ) );
+        }
+
+
+        function admin_init() {
+            $now = strtotime( 'now' );
+            $last_checked = (int) get_option( 'ghu_last_checked' );
+            $check_interval = apply_filters( 'ghu_check_interval', ( 60 * 60 * 12 ) );
+            $this->update_data = (array) get_option( 'ghu_update_data' );
+            $active = (array) get_option( 'active_plugins' );
+
+            foreach ( $active as $slug ) {
+                $this->active_plugins[ $slug ] = true;
+            }
+
+            // transient expiration
+            if ( ( $now - $last_checked ) > $check_interval ) {
+                $this->update_data = $this->get_github_updates();
+
+                update_option( 'ghu_update_data', $this->update_data );
+                update_option( 'ghu_last_checked', $now );
+            }
+        }
+
+
+        /**
+         * Fetch the latest GitHub tags and build the plugin data array
+         */
+        function get_github_updates() {
+            $plugin_data = array();
+            $plugins = get_plugins();
+            foreach ( $plugins as $slug => $info ) {
+                if ( isset( $this->active_plugins[ $slug ] ) && ! empty( $info['GitHub URI'] ) ) {
+                    $temp = array(
+                        'plugin'            => $slug,
+                        'slug'              => trim( dirname( $slug ), '/' ),
+                        'name'              => $info['Name'],
+                        'github_repo'       => $info['GitHub URI'],
+                        'description'       => $info['Description'],
+                    );
+
+                    // get plugin tags
+                    list( $owner, $repo ) = explode( '/', $temp['github_repo'] );
+                    $request = wp_remote_get( "https://api.github.com/repos/$owner/$repo/tags" );
+
+                    // WP error or rate limit exceeded
+                    if ( is_wp_error( $request ) || 200 != wp_remote_retrieve_response_code( $request ) ) {
+                        break;
+                    }
+
+                    $json = json_decode( $request['body'], true );
+
+                    if ( is_array( $json ) && ! empty( $json ) ) {
+                        $latest_tag = $json[0];
+                        $temp['new_version'] = $latest_tag['name'];
+                        $temp['url'] = "https://github.com/$owner/$repo/";
+                        $temp['package'] = $latest_tag['zipball_url'];
+                        $plugin_data[ $slug ] = $temp;
+                    }
+                }
+            }
+
+            return $plugin_data;
+        }
+
+
+        /**
+         * Get plugin info for the "View Details" popup
+         */
+        function plugins_api( $default = false, $action, $args ) {
+            if ( 'plugin_information' == $action ) {
+                if ( isset( $this->update_data[ $args->slug ] ) ) {
+                    $plugin = $this->update_data[ $args->slug ];
+
+                    return (object) array(
+                        'name'          => $plugin['name'],
+                        'slug'          => $plugin['plugin'],
+                        'version'       => $plugin['new_version'],
+                        'requires'      => '4.7',
+                        'tested'        => get_bloginfo( 'version' ),
+                        'last_updated'  => date( 'Y-m-d' ),
+                        'sections' => array(
+                            'description' => $plugin['description']
+                        )
+                    );
+                }
+            }
+
+            return $default;
+        }
+
+
+        function set_update_data( $transient ) {
+            if ( empty( $transient->checked ) ) {
+                return $transient;
+            }
+
+            foreach ( $this->update_data as $plugin => $info ) {
+                if ( isset( $this->active_plugins[ $plugin ] ) ) {
+                    $plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
+                    $version = $plugin_data['Version'];
+
+                    if ( version_compare( $version, $info['new_version'], '<' ) ) {
+                        $transient->response[ $plugin ] = (object) $info;
+                    }
+                }
+            }
+
+            return $transient;
+        }
+
+
+        /**
+         * Rename the plugin folder
+         */
+        function upgrader_source_selection( $source, $remote_source, $upgrader, $hook_extra = null ) {
+            global $wp_filesystem;
+
+            $plugin = isset( $hook_extra['plugin'] ) ? $hook_extra['plugin'] : false;
+            if ( isset( $this->update_data[ $plugin ] ) && $plugin ) {
+                $new_source = trailingslashit( $remote_source ) . dirname( $plugin );
+                $wp_filesystem->move( $source, $new_source );
+                return trailingslashit( $new_source );
+            }
+
+            return $source;
+        }
+
+
+        /**
+         * Parse the "GitHub URI" config too
+         */
+        function extra_plugin_headers( $headers ) {
+            $headers[] = 'GitHub URI';
+            return $headers;
+        }
+    }
+
+    new GHU_Core();
+}

--- a/includes/class-wc-coupon-restrictions-validation.php
+++ b/includes/class-wc-coupon-restrictions-validation.php
@@ -287,7 +287,7 @@ class WC_Coupon_Restrictions_Validation {
 
 					// Check if coupon is restricted to new customers.
 					if ( 'new' == $customer_restriction_type ) {
-						$valid = self::check_new_customer_coupon_checkout();
+						$valid = self::check_new_customer_coupon_checkout( $coupon, $code );
 					}
 
 					// Check if coupon is restricted to existing customers.

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 * Tags: woocommerce, coupon
 * Requires at least: 4.7.0
 * Tested up to: 4.9.4
-* Stable tag: 1.5.0
+* Stable tag: 1.5.1
 * License: GPLv2 or later
 * License URI: http://www.gnu.org/licenses/gpl-2.0.html
 * WC requires at least: 3.3.0
@@ -46,6 +46,10 @@ https://github.com/devinsays/woocommerce-coupon-restrictions/wiki/Unit-Tests
 * Requires WooCommerce 3.2.1 or later.
 
 ## Changelog
+
+**1.5.1 (05.19.18)**
+* Integration of Github Updater Lite : https://github.com/FacetWP/github-updater-lite
+* Plugin will check every 12 hours for a new build/release on https://github.com/devinsays/woocommerce-coupon-restrictions and allow updating from within Wordpress.
 
 **1.5.0 (05.17.18)**
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: @downstairsdev
 Tags: woocommerce, coupon
 Requires at least: 4.7.0
 Tested up to: 4.9.4
-Stable tag: 1.5.0
+Stable tag: 1.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 3.3.0
@@ -39,6 +39,10 @@ A customer must meet all requirements if multiple restrictions are set. For inst
 * Requires WooCommerce 3.2.1 or later.
 
 == Changelog ==
+
+=1.5.1 (05.19.18)=
+* Integration of Github Updater Lite : https://github.com/FacetWP/github-updater-lite
+* Plugin will check every 12 hours for a new build/release on https://github.com/devinsays/woocommerce-coupon-restrictions and allow updating from within Wordpress.
 
 = 1.5.0 (05.17.18)=
 

--- a/woocommerce-coupon-restrictions.php
+++ b/woocommerce-coupon-restrictions.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Coupon Restrictions
  * Plugin URI: https://devpress.com/products/woocommerce-coupon-restrictions/
  * Description: Allows for additional coupon restrictions. Coupons can be restricted to new customers, existing customers, or by country.
- * Version: 1.5.0
+ * Version: 1.5.1
  * Author: DevPress
  * Author URI: https://devpress.com
  *
@@ -17,6 +17,8 @@
  *
  * Text Domain: woocommerce-coupon-restrictions
  * Domain Path: /languages
+ * GitHub Plugin URI: https://github.com/devinsays/woocommerce-coupon-restrictions.git
+ * GitHub URI: devinsays/woocommerce-coupon-restrictions
  */
 
 // If this file is called directly, abort.

--- a/woocommerce-coupon-restrictions.php
+++ b/woocommerce-coupon-restrictions.php
@@ -26,6 +26,8 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+include( dirname( __FILE__ ) . '/github-updater.php' );
+
 if ( ! class_exists( 'WC_Coupon_Restrictions' ) ) :
 class WC_Coupon_Restrictions {
 


### PR DESCRIPTION
I don't know how to Github, and I don't know the normal procedures for all of this and I'm not a programmer, but here is my attempt to contribute. 

These if I recall are all the steps neccesary to integrate Github Updater Lite.
Default time to check is 12 hours, to change it ( I change it myself usually to 10 minutes but left it as is on the Github Updater Lite repo)  go to github-updater.php Line 24 

Github Updater Lite works with builds / releases, not just changes. So once everyone updates with the version with GUL, whenever you make a new build / release they will get notified.

* Create / upload file: github-updater.php 
* Updated Readme.txt / .md
* Modify woocommerce-coupon-restrictions.php

` Line 6: * Version: 1.5.1`
` Line 20: * GitHub Plugin URI: https://github.com/devinsays/woocommerce-coupon-restrictions.git`

`Line 21: * GitHub URI: devinsays/woocommerce-coupon-restrictions`

`Line 29: include( dirname( __FILE__ ) . '/github-updater.php' );`