### PR TITLE
Enhancement: Adds "Guest (No Account)" option to the roles restriction

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Coupon Restrictions Changelog ***
 
+2021-03-28 - version 1.8.3
+
+* Enhancement: Adds "Guest (No Account)" option to the roles restriction.
+
 2021-01-12 - version 1.8.2
 
 * Enhancement: Reduces use of coupon meta by only storing non-default values.

--- a/includes/class-wc-coupon-restrictions-admin.php
+++ b/includes/class-wc-coupon-restrictions-admin.php
@@ -86,6 +86,11 @@ class WC_Coupon_Restrictions_Admin {
 
 		// An array of all roles.
 		$roles = array_reverse( get_editable_roles() );
+
+		// Adds a fabricated role for "Guest" to allow guest checkouts.
+		$roles['woocommerce-coupon-restrictions-guest'] = array(
+			'name' => __( 'Guest (No User Account)', 'woocommerce-coupon-restrictions' ),
+		);
 		?>
 		<div class="options_group">
 			<p class="form-field <?php echo $id; ?>_only_field">

--- a/includes/class-wc-coupon-restrictions-validation.php
+++ b/includes/class-wc-coupon-restrictions-validation.php
@@ -395,7 +395,12 @@ class WC_Coupon_Restrictions_Validation {
 		// Checks if there is an account associated with the $email.
 		$user = get_user_by( 'email', $email );
 
-		// If user account does not exist, coupon is invalid.
+		// If user account does not exist and guest role is permitted, return true.
+		if ( ! $user && in_array( 'woocommerce-coupon-restrictions-guest', $restricted_roles ) ) {
+			return true;
+		}
+
+		// If user account does not exist and guest role not permitted, coupon is invalid.
 		if ( ! $user ) {
 			return false;
 		}

--- a/languages/woocommerce-new-customer-coupons.pot
+++ b/languages/woocommerce-new-customer-coupons.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Coupon Restrictions 1.8.1\n"
+"Project-Id-Version: WooCommerce Coupon Restrictions 1.8.2\n"
 "Report-Msgid-Bugs-To: https://devpress.com/\n"
-"POT-Creation-Date: 2021-01-09 04:15:48+00:00\n"
+"POT-Creation-Date: 2021-03-27 21:15:10+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -44,31 +44,35 @@ msgstr ""
 msgid "Existing customers only"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:80
+#: includes/class-wc-coupon-restrictions-admin.php:79
 msgid "User role restriction"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:96
+#: includes/class-wc-coupon-restrictions-admin.php:92
+msgid "Guest (No User Account)"
+msgstr ""
+
+#: includes/class-wc-coupon-restrictions-admin.php:100
 msgid "Choose roles&hellip;"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:96
+#: includes/class-wc-coupon-restrictions-admin.php:100
 msgid "Role"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:127
+#: includes/class-wc-coupon-restrictions-admin.php:130
 msgid "Use location restrictions"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:128
+#: includes/class-wc-coupon-restrictions-admin.php:131
 msgid "Displays and enables location restriction options."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:139
+#: includes/class-wc-coupon-restrictions-admin.php:142
 msgid "Address for location restrictions"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:142
+#: includes/class-wc-coupon-restrictions-admin.php:145
 #: vendor/woocommerce/woocommerce-src-latest/includes/admin/class-wc-admin-setup-wizard.php:284
 #: vendor/woocommerce/woocommerce-src-latest/includes/admin/class-wc-admin-setup-wizard.php:1086
 #: vendor/woocommerce/woocommerce-src-latest/includes/admin/meta-boxes/class-wc-meta-box-order-data.php:430
@@ -86,59 +90,59 @@ msgstr ""
 msgid "Shipping"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:143
+#: includes/class-wc-coupon-restrictions-admin.php:146
 #: vendor/woocommerce/woocommerce-src-latest/includes/admin/list-tables/class-wc-admin-list-table-orders.php:124
 #: vendor/woocommerce/woocommerce-src-latest/includes/admin/meta-boxes/class-wc-meta-box-order-data.php:314
 msgid "Billing"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:150
+#: includes/class-wc-coupon-restrictions-admin.php:153
 msgid "Restrict to specific countries"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:170
+#: includes/class-wc-coupon-restrictions-admin.php:172
 msgid "Choose countries&hellip;"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:170
+#: includes/class-wc-coupon-restrictions-admin.php:172
 msgid "Country"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:187
+#: includes/class-wc-coupon-restrictions-admin.php:189
 msgid "Select any country that your store currently sells to."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:189
+#: includes/class-wc-coupon-restrictions-admin.php:191
 msgid "Adds all the countries that the store sells to in the restricted field."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:190
+#: includes/class-wc-coupon-restrictions-admin.php:192
 msgid "Add All Countries"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:192
+#: includes/class-wc-coupon-restrictions-admin.php:194
 msgid "Clears all restricted country selections."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:193
+#: includes/class-wc-coupon-restrictions-admin.php:195
 #: vendor/woocommerce/woocommerce-src-latest/packages/woocommerce-rest-api/src/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php:163
 #: vendor/woocommerce/woocommerce-src-latest/templates/single-product/add-to-cart/variable.php:48
 msgid "Clear"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:202
+#: includes/class-wc-coupon-restrictions-admin.php:204
 msgid "Restrict to specific states"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:203
+#: includes/class-wc-coupon-restrictions-admin.php:205
 msgid "Use the two digit state codes. Comma separate to specify multiple states."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:213
+#: includes/class-wc-coupon-restrictions-admin.php:215
 msgid "Restrict to specific zip codes"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:214
+#: includes/class-wc-coupon-restrictions-admin.php:216
 msgid ""
 "Comma separate to list multiple zip codes. Wildcards (*) can be used to "
 "match portions of zip codes."
@@ -285,39 +289,39 @@ msgstr ""
 msgid "Verify new customers by checking against user accounts and all guest orders."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-validation.php:654
+#: includes/class-wc-coupon-restrictions-validation.php:659
 msgid "shipping"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-validation.php:655
+#: includes/class-wc-coupon-restrictions-validation.php:660
 msgid "billing"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-validation.php:659
+#: includes/class-wc-coupon-restrictions-validation.php:664
 msgid "Sorry, coupon code \"%s\" is only valid for new customers."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-validation.php:663
+#: includes/class-wc-coupon-restrictions-validation.php:668
 msgid "Sorry, coupon code \"%s\" is only valid for existing customers."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-validation.php:667
+#: includes/class-wc-coupon-restrictions-validation.php:672
 msgid "Sorry, coupon code \"%s\" is not valid with your customer role."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-validation.php:673
+#: includes/class-wc-coupon-restrictions-validation.php:678
 msgid "Sorry, coupon code \"%s\" is not valid in your %s country."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-validation.php:679
+#: includes/class-wc-coupon-restrictions-validation.php:684
 msgid "Sorry, coupon code \"%s\" is not valid in your %s state."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-validation.php:685
+#: includes/class-wc-coupon-restrictions-validation.php:690
 msgid "Sorry, coupon code \"%s\" is not valid in your %s zip code."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-validation.php:690
+#: includes/class-wc-coupon-restrictions-validation.php:695
 msgid "Sorry, coupon code \"%s\" is not valid."
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-coupon-restrictions",
-	"version": "1.8.2",
+	"version": "1.8.3",
 	"repository": "https://github.com/devinsays/woocommerce-coupon-restrictions",
 	"license": "GPL-2.0",
 	"devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -3,13 +3,13 @@
 * Contributors: @downstairsdev
 * Tags: woocommerce, coupon
 * Requires at least: 4.9.0
-* Tested up to: 5.6
+* Tested up to: 5.7
 * Requires PHP: 7.0
-* Stable tag: 1.8.2
+* Stable tag: 1.8.3
 * License: GPLv3 or later License
 * License URI: http://www.gnu.org/licenses/gpl-3.0.html
 * WC requires at least: 3.9.3
-* WC tested up to: 4.8.0
+* WC tested up to: 5.1.0
 
 ## Description
 
@@ -19,7 +19,7 @@ This extension allows you to create coupons with addition restriction options:
 
 **Existing customer restriction**: Verifies that the custom does have an account with completed purchases before applying a coupon.
 
-**User role restriction**: Limits a coupon to specific user roles. So if you have custom roles for wholesalers, affiliates, or vips, you can provide coupons that will only work for them.
+**User role restriction**: Limits a coupon to specific user roles. If you have custom roles for wholesale customers, affiliates, or vips, you can provide coupons that will only work for them.
 
 **Country restriction**: Allows you to restrict a coupon to specific countries. Restriction can be applied to shipping or billing country.
 
@@ -51,6 +51,10 @@ https://github.com/devinsays/woocommerce-coupon-restrictions/wiki/Unit-Tests
 * Requires WooCommerce 3.9.0 or later.
 
 ## Changelog
+
+**1.8.3**
+
+* Enhancement: Adds "Guest (No Account)" option to the roles restriction.
 
 **1.8.2**
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,13 +3,13 @@
 Contributors: @downstairsdev
 Tags: woocommerce, coupon
 Requires at least: 4.9.0
-Tested up to: 5.6
+Tested up to: 5.7
 Requires PHP: 7.0
-Stable tag: 1.8.2
+Stable tag: 1.8.3
 License: GPLv3 or later License
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 WC requires at least: 3.9.3
-WC tested up to: 4.8.0
+WC tested up to: 5.1.0
 Woo: 3200406:6d7b7aa4f9565b8f7cbd2fe10d4f119a
 
 == Description ==
@@ -20,7 +20,7 @@ New customer restriction: Verifies that the customer does not have an account wi
 
 Existing customer restriction: Verifies that the custom does have an account with completed purchases before applying a coupon.
 
-User role restriction: Limits a coupon to specific user roles. So if you have custom roles for wholesalers, affiliates, or vips, you can provide coupons that will only work for them.
+User role restriction: Limits a coupon to specific user roles. If you have custom roles for wholesale customers, affiliates, or vips, you can provide coupons that will only work for them.
 
 Country restriction: Allows you to restrict a coupon to specific countries. Restriction can be applied to shipping or billing country.
 

--- a/tests/phpunit/Integration/ApplyRoleRestrictionCouponTest.php
+++ b/tests/phpunit/Integration/ApplyRoleRestrictionCouponTest.php
@@ -130,7 +130,7 @@ class Apply_Role_Restriction_Coupon_Test extends WP_UnitTestCase {
 		);
 		WC_Helper_Customer::set_customer_details( $session );
 
-		// Coupon not should apply because customer does not have an account
+		// Coupon should not apply because customer does not have an account
 		// and the role restriction does not allow guests.
 		$this->assertFalse( WC()->cart->apply_coupon( $coupon->get_code() ) );
 		$this->assertEquals( 0, count( WC()->cart->get_applied_coupons() ) );

--- a/tests/phpunit/Integration/ApplyRoleRestrictionCouponTest.php
+++ b/tests/phpunit/Integration/ApplyRoleRestrictionCouponTest.php
@@ -90,6 +90,51 @@ class Apply_Role_Restriction_Coupon_Test extends WP_UnitTestCase {
 		// Coupon should apply because customer role and restriction match.
 		$this->assertTrue( WC()->cart->apply_coupon( $coupon->get_code() ) );
 		$this->assertEquals( 1, count( WC()->cart->get_applied_coupons() ) );
+
+	}
+
+	/**
+	 * Coupon will apply because customer is guest and guest role is permitted.
+	 */
+	public function test_coupon_success_if_guest_and_guest_role_set() {
+
+		// Creates a coupon.
+		$coupon = WC_Helper_Coupon::create_coupon();
+		$coupon->update_meta_data( 'role_restriction', ['woocommerce-coupon-restrictions-guest'] );
+		$coupon->save();
+
+		// Create a mock customer session.
+		$session = array(
+			'email' => 'guest@testing.dev'
+		);
+		WC_Helper_Customer::set_customer_details( $session );
+
+		// Coupon should apply because customer does not have an account
+		// and the role restriction allows guests.
+		$this->assertTrue( WC()->cart->apply_coupon( $coupon->get_code() ) );
+		$this->assertEquals( 1, count( WC()->cart->get_applied_coupons() ) );
+
+	}
+
+	/**
+	 * Coupon will not apply because customer is guest and guest role is not permitted.
+	 */
+	public function test_coupon_fails_if_guest_and_guest_role_not_set() {
+
+		// Get data from setup for coupon restricted to administrators (no guest role).
+		$coupon = $this->coupon;
+
+		// Create a mock customer session.
+		$session = array(
+			'email' => 'guest@testing.dev'
+		);
+		WC_Helper_Customer::set_customer_details( $session );
+
+		// Coupon not should apply because customer does not have an account
+		// and the role restriction does not allow guests.
+		$this->assertFalse( WC()->cart->apply_coupon( $coupon->get_code() ) );
+		$this->assertEquals( 0, count( WC()->cart->get_applied_coupons() ) );
+
 	}
 
 

--- a/woocommerce-coupon-restrictions.php
+++ b/woocommerce-coupon-restrictions.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Coupon Restrictions
  * Plugin URI: http://woocommerce.com/products/woocommerce-coupon-restrictions/
  * Description: Adds additional coupon restrictions. Coupons can be restricted to new customers, existing customers, or specific locations.
- * Version: 1.8.2
+ * Version: 1.8.3
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
  * Developer: Devin Price
@@ -13,7 +13,7 @@
  *
  * Woo: 3200406:6d7b7aa4f9565b8f7cbd2fe10d4f119a
  * WC requires at least: 3.9.0
- * WC tested up to: 4.8.0
+ * WC tested up to: 5.1.0
  *
  * Copyright: © 2015-2021 DevPress.
  * License: GNU General Public License v3.0


### PR DESCRIPTION
Allows coupons to be created with a role restriction of "Guest". This is a fabricated role, since customers without an account will not have an actual user role. But this allows shop administrators to create coupons that can be restricted to "Guests" and "Customers" for example, but excludes "Wholesale" or other types of roles.