### PR TITLE
Bugfix: Coupon verification records were not storing properly

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Coupon Restrictions Changelog ***
 
+2023-02-10 - version 2.1.0
+
+* Bugfix: Coupon verification records were not storing properly on checkouts with payment.
+
 2023-01-02 - version 2.0.0
 
 * Update: Major plugin rewrite.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 2023-02-10 - version 2.1.0
 
 * Bugfix: Coupon verification records were not storing properly on checkouts with payment.
+* Bugfix: Show compatibility notice if WooCommerce is not active.
 
 2023-01-02 - version 2.0.0
 

--- a/includes/class-wc-coupon-restrictions-table.php
+++ b/includes/class-wc-coupon-restrictions-table.php
@@ -98,7 +98,6 @@ class WC_Coupon_Restrictions_Table {
 	 * @return array
 	 */
 	public static function maybe_add_record_on_payment( $result, $order_id ) {
-		error_log('maybe_add_record_on_payment');
 		self::maybe_add_record( $order_id );
 		return $result;
 	}
@@ -111,7 +110,6 @@ class WC_Coupon_Restrictions_Table {
 	 * @return array
 	 */
 	public static function maybe_add_record( $order_id ) {
-		error_log( 'maybe_add_record' );
 		$order = wc_get_order( $order_id );
 
 		// Check all the coupons.

--- a/includes/class-wc-coupon-restrictions-table.php
+++ b/includes/class-wc-coupon-restrictions-table.php
@@ -17,13 +17,14 @@ class WC_Coupon_Restrictions_Table {
 	 * Constructor.
 	 */
 	public function __construct() {
-		// This is if the order can be completed immediately.
+		// We'll store a record in the verification table if customer uses a coupon with enhanced usage limits.
+		// The woocommerce_pre_payment_complete is when if the order does not require a payment.
+		// This can happen if the coupon brings the order price to zero.
+		// The woocommerce_payment_successful_result filter is used when the order does require a payment.
 		add_action( 'woocommerce_pre_payment_complete', array( $this, 'maybe_add_record' ), 100 );
-
-		// This is if the order does require a payment.
 		add_filter( 'woocommerce_payment_successful_result', array( $this, 'maybe_add_record_on_payment' ), 100, 2 );
 
-		// This removes the record if the order is cancelled.
+		// This removes the record in the verification table if the order is cancelled.
 		add_action( 'woocommerce_order_status_cancelled', array( $this, 'maybe_update_record_status' ), 10 );
 	}
 

--- a/languages/woocommerce-coupon-restrictions.pot
+++ b/languages/woocommerce-coupon-restrictions.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Coupon Restrictions 2.0.0\n"
+"Project-Id-Version: WooCommerce Coupon Restrictions 2.1.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-coupon-restrictions\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-01-02T19:32:16+00:00\n"
+"POT-Creation-Date: 2023-02-11T03:22:28+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.6.0\n"
 "X-Domain: woocommerce-coupon-restrictions\n"
@@ -300,6 +300,6 @@ msgstr ""
 msgid "Using WooCommerce %1$s."
 msgstr ""
 
-#: woocommerce-coupon-restrictions.php:113
-msgid "%1$s requires at least %2$s v%3$s in order to function. Please upgrade %2$s."
+#: woocommerce-coupon-restrictions.php:97
+msgid "%1$s requires at least %2$s v%3$s in order to function."
 msgstr ""

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,8 @@
 -   WP requires at least: 4.9.0
 -   WP tested up to: 6.1.1
 -   WC requires at least: 4.8.1
--   WC tested up to: 7.2.2
--   Stable tag: 2.0.0
+-   WC tested up to: 7.3.0
+-   Stable tag: 2.1.0
 -   License: [GPLv3 or later License](http://www.gnu.org/licenses/gpl-3.0.html)
 
 ## Description
@@ -66,6 +66,7 @@ To run the code checks from the command line run: `vendor/bin/phpcs`
 **2.1.0 (02.10.23)**
 
 -   Bugfix: Coupon verification records were not storing properly on checkouts with payment.
+-   Bugfix: Show compatibility notice if WooCommerce is not active.
 
 **2.0.0 (01.02.23)**
 
@@ -92,7 +93,7 @@ To run the code checks from the command line run: `vendor/bin/phpcs`
 
 -   Enhancement: Adds "Guest (No Account)" option to the roles restriction.
 
-**1.8.2**
+**1.8.2 (01.12.21)**
 
 -   Enhancement: Reduces use of coupon meta by only storing non-default values.
 -   Update: Tested to WooCommerce 4.8.0.

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,10 @@ To run the code checks from the command line run: `vendor/bin/phpcs`
 
 ## Changelog
 
+**2.1.0 (02.10.23)**
+
+-   Bugfix: Coupon verification records were not storing properly on checkouts with payment.
+
 **2.0.0 (01.02.23)**
 
 -   Update: Major plugin rewrite.

--- a/readme.txt
+++ b/readme.txt
@@ -5,9 +5,9 @@ Tags: woocommerce, coupon
 Requires at least: 4.9.0
 Tested up to: 6.1.1
 Requires PHP: 7.2
-Stable tag: 2.0.0
+Stable tag: 2.1.0
 License: GPLv3 or later License
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 WC requires at least: 4.8.1
-WC tested up to: 7.2.2
+WC tested up to: 7.3.0
 Woo: 3200406:6d7b7aa4f9565b8f7cbd2fe10d4f119a

--- a/tests/phpunit/Integration/OnboardingSetupTest.php
+++ b/tests/phpunit/Integration/OnboardingSetupTest.php
@@ -31,7 +31,7 @@ class Onboarding_Setup_Test extends WP_UnitTestCase {
 
 		// This will kick off the upgrade routine.
 		$plugin = WC_Coupon_Restrictions();
-		$plugin->init_plugin();
+		$plugin->init();
 
 		$query_type = get_option( 'coupon_restrictions_customer_query', 'account' );
 		$this->assertEquals( $query_type, 'accounts-orders' );

--- a/woocommerce-coupon-restrictions.php
+++ b/woocommerce-coupon-restrictions.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Coupon Restrictions
  * Plugin URI: http://woocommerce.com/products/woocommerce-coupon-restrictions/
  * Description: Create targeted coupons for new customers, user roles, countries or zip codes. Prevent coupon abuse with enhanced usage limits.
- * Version: 2.0.0
+ * Version: 2.1.0
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
  * Developer: Devin Price
@@ -13,7 +13,7 @@
  *
  * Woo: 3200406:6d7b7aa4f9565b8f7cbd2fe10d4f119a
  * WC requires at least: 4.8.1
- * WC tested up to: 7.2.2
+ * WC tested up to: 7.3.0
  *
  * Copyright: © 2015-2023 DevPress.
  * License: GNU General Public License v3.0
@@ -32,7 +32,7 @@ if ( ! class_exists( 'WC_Coupon_Restrictions' ) ) {
 		public static $instance;
 
 		/** @var string */
-		public $version = '2.0.0';
+		public $version = '2.1.0';
 
 		/** @var string */
 		public $required_woo = '4.8.1';
@@ -64,11 +64,8 @@ if ( ! class_exists( 'WC_Coupon_Restrictions' ) ) {
 		public function __construct() {
 			$this->plugin_path = untrailingslashit( plugin_dir_path( __FILE__ ) );
 
-			// Checks WooCommerce version.
-			add_action( 'plugins_loaded', array( $this, 'load_plugin' ) );
-
 			// Init hooks runs after plugins_loaded and woocommerce_loaded hooks.
-			add_action( 'init', array( $this, 'init_plugin' ) );
+			add_action( 'init', array( $this, 'init' ) );
 		}
 
 		/**
@@ -91,26 +88,13 @@ if ( ! class_exists( 'WC_Coupon_Restrictions' ) ) {
 		}
 
 		/**
-		 * Check requirements on activation.
-		 *
-		 * @since  1.3.0
-		 */
-		public function load_plugin() {
-			// Check we're running the required version of WooCommerce.
-			if ( ! defined( 'WC_VERSION' ) || version_compare( WC_VERSION, $this->required_woo, '<' ) ) {
-				add_action( 'admin_notices', array( $this, 'woocommerce_compatibility_notice' ) );
-				return false;
-			}
-		}
-
-		/**
 		 * Display a warning message if minimum version of WooCommerce check fails.
 		 *
 		 * @since  1.3.0
 		 * @return void
 		 */
 		public function woocommerce_compatibility_notice() {
-			echo '<div class="error"><p>' . sprintf( __( '%1$s requires at least %2$s v%3$s in order to function. Please upgrade %2$s.', 'woocommerce-coupon-restrictions' ), 'WooCommerce Coupon Restrictions', 'WooCommerce', $this->required_woo ) . '</p></div>';
+			echo '<div class="error"><p>' . sprintf( __( '%1$s requires at least %2$s v%3$s in order to function.', 'woocommerce-coupon-restrictions' ), 'WooCommerce Coupon Restrictions', 'WooCommerce', $this->required_woo ) . '</p></div>';
 		}
 
 		/**
@@ -119,7 +103,13 @@ if ( ! class_exists( 'WC_Coupon_Restrictions' ) ) {
 		 * @since  1.3.0
 		 * @return void
 		 */
-		public function init_plugin() {
+		public function init() {
+			// Check if we're running the required version of WooCommerce.
+			if ( ! defined( 'WC_VERSION' ) || version_compare( WC_VERSION, $this->required_woo, '<' ) ) {
+				add_action( 'admin_notices', array( $this, 'woocommerce_compatibility_notice' ) );
+				return false;
+			}
+
 			// Load translations.
 			load_plugin_textdomain(
 				'woocommerce-coupon-restrictions',


### PR DESCRIPTION
Records were being added for $0 orders, but not orders with payments > $0.

Kind of a problem.

This fixes it.