### PR TITLE
Update: Docblocks, deprecated method, v2.3.3

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,12 @@
 *** WooCommerce Coupon Restrictions Changelog ***
 
+2024-02-25 - version 2.2.3
+
+* Update: Declare compatibility with latest version of WooCommerce.
+* Update: Fix deprecated call to is_coupon_valid.
+* Update: Improve docblock documentation.
+* Update: Improve automated testing suite.
+
 2024-02-05 - version 2.2.2
 
 * Bugfix: Add explicit check for array type for meta values that require it.

--- a/includes/class-wc-coupon-restrictions-admin.php
+++ b/includes/class-wc-coupon-restrictions-admin.php
@@ -34,7 +34,7 @@ class WC_Coupon_Restrictions_Admin {
 	 * @since  1.3.0
 	 *
 	 * @param int $coupon_id
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @return void
 	 */
 	public static function customer_restrictions( $coupon_id, $coupon ) {
@@ -70,7 +70,7 @@ class WC_Coupon_Restrictions_Admin {
 	 * @since  1.8.0
 	 *
 	 * @param int $coupon_id
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @return void
 	 */
 	public static function role_restrictions( $coupon_id, $coupon ) {
@@ -117,8 +117,8 @@ class WC_Coupon_Restrictions_Admin {
 	 *
 	 * @since  1.3.0
 	 *
-	 * @param int $id
-	 * @param object $coupon
+	 * @param int $coupon_id
+	 * @param WC_Coupon $coupon
 	 * @return void
 	 */
 	public static function location_restrictions( $coupon_id, $coupon ) {
@@ -232,7 +232,7 @@ class WC_Coupon_Restrictions_Admin {
 	 * @since  1.7.0
 	 *
 	 * @param int $coupon_id
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @return void
 	 */
 	public static function usage_limits( $coupon_id, $coupon ) {
@@ -333,7 +333,7 @@ class WC_Coupon_Restrictions_Admin {
 	 *
 	 * @since  1.3.0
 	 * @param int $coupon_id
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 *
 	 * @return void
 	 */

--- a/includes/class-wc-coupon-restrictions-onboarding.php
+++ b/includes/class-wc-coupon-restrictions-onboarding.php
@@ -169,6 +169,7 @@ class WC_Coupon_Restrictions_Onboarding {
 	/**
 	 * Init pointers for screen.
 	 *
+	 * @return void
 	 * @since 1.5.0
 	 */
 	public function init_pointers_for_screen() {
@@ -293,7 +294,8 @@ class WC_Coupon_Restrictions_Onboarding {
 	 * Follow WooCommerce core pattern:
 	 * https://github.com/woocommerce/woocommerce/blob/master/includes/admin/class-wc-admin-pointers.php
 	 *
-	 * @param array $pointers
+	 * @param array $pointers Array of pointers with their settings
+	 * @return void
 	 *
 	 * @since 1.5.0
 	 */

--- a/includes/class-wc-coupon-restrictions-settings.php
+++ b/includes/class-wc-coupon-restrictions-settings.php
@@ -18,8 +18,11 @@ class WC_Coupon_Restrictions_Settings {
 	}
 
 	/**
-	* Adds our coupon restriction settings.
-	*/
+	 * Adds our coupon restriction settings.
+	 *
+	 * @param array $settings WooCommerce settings array
+	 * @return array Modified settings array
+	 */
 	public function coupon_restrictions_settings( $settings ) {
 		$coupon_restrictions = array(
 			'title'    => __( 'Coupon Restrictions', 'woocommerce' ),

--- a/includes/class-wc-coupon-restrictions-validation-cart.php
+++ b/includes/class-wc-coupon-restrictions-validation-cart.php
@@ -21,7 +21,7 @@ class WC_Coupon_Restrictions_Validation_Cart {
 	 * Validates coupon if customer session data is available.
 	 *
 	 * @param boolean $valid
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @return boolean
 	 */
 	public function validate_coupons_before_checkout( $valid, $coupon ) {
@@ -107,7 +107,7 @@ class WC_Coupon_Restrictions_Validation_Cart {
 	 * Validates customer restrictions.
 	 * Returns true if customer meets $coupon criteria.
 	 *
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @param string $email
 	 * @return boolean
 	 */

--- a/includes/class-wc-coupon-restrictions-validation-checkout.php
+++ b/includes/class-wc-coupon-restrictions-validation-checkout.php
@@ -38,7 +38,7 @@ class WC_Coupon_Restrictions_Validation_Checkout {
 		foreach ( WC()->cart->applied_coupons as $code ) {
 			$coupon = new WC_Coupon( $code );
 
-			if ( ! $coupon->is_valid() ) {
+			if ( ! wc_coupons_enabled() || ! WC_Discounts::is_coupon_valid( $coupon ) ) {
 				continue;
 			}
 

--- a/includes/class-wc-coupon-restrictions-validation-checkout.php
+++ b/includes/class-wc-coupon-restrictions-validation-checkout.php
@@ -38,7 +38,8 @@ class WC_Coupon_Restrictions_Validation_Checkout {
 		foreach ( WC()->cart->applied_coupons as $code ) {
 			$coupon = new WC_Coupon( $code );
 
-			if ( ! wc_coupons_enabled() || ! WC_Discounts::is_coupon_valid( $coupon ) ) {
+			$discounts = new WC_Discounts( WC()->cart );
+			if ( ! wc_coupons_enabled() || ! $discounts->is_coupon_valid( $coupon ) ) {
 				continue;
 			}
 

--- a/includes/class-wc-coupon-restrictions-validation-checkout.php
+++ b/includes/class-wc-coupon-restrictions-validation-checkout.php
@@ -58,8 +58,9 @@ class WC_Coupon_Restrictions_Validation_Checkout {
 	/**
 	 * Validates new customer coupon on checkout.
 	 *
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @param string $code
+	 * @param array $posted
 	 * @return void
 	 */
 	public function validate_new_customer_restriction( $coupon, $code, $posted ) {
@@ -75,7 +76,7 @@ class WC_Coupon_Restrictions_Validation_Checkout {
 	/**
 	 * Validates existing customer coupon on checkout.
 	 *
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @param string $code
 	 * @param array $posted
 	 * @return void
@@ -91,10 +92,11 @@ class WC_Coupon_Restrictions_Validation_Checkout {
 	}
 
 	/**
-	 * Validates new customer coupon on checkout.
+	 * Validates role restriction on checkout.
 	 *
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @param string $code
+	 * @param array $posted
 	 * @return void
 	 */
 	public function validate_role_restriction( $coupon, $code, $posted ) {
@@ -111,7 +113,7 @@ class WC_Coupon_Restrictions_Validation_Checkout {
 	 * Validates location restrictions.
 	 * Returns true if customer meets $coupon criteria.
 	 *
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @param string $code
 	 * @param array $posted
 	 * @return void
@@ -171,8 +173,9 @@ class WC_Coupon_Restrictions_Validation_Checkout {
 	/**
 	 * Validates similar emails restriction.
 	 *
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @param string $code
+	 * @param array $posted
 	 * @return void
 	 */
 	public function validate_similar_emails_restriction( $coupon, $code, $posted ) {
@@ -197,8 +200,9 @@ class WC_Coupon_Restrictions_Validation_Checkout {
 	/**
 	 * Validates usage limit per shipping address.
 	 *
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @param string $code
+	 * @param array $posted
 	 * @return void
 	 */
 	public function validate_usage_limit_per_shipping_address( $coupon, $code, $posted ) {
@@ -215,9 +219,9 @@ class WC_Coupon_Restrictions_Validation_Checkout {
 	}
 
 	/**
-	 * Validates enhanced usage restrictions.
+	 * Validates usage limit per IP address.
 	 *
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @param string $code
 	 * @return void
 	 */
@@ -237,7 +241,7 @@ class WC_Coupon_Restrictions_Validation_Checkout {
 	/**
 	 * Removes coupon and displays a validation message.
 	 *
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @param string $code
 	 * @param string $msg
 	 * @return void

--- a/includes/class-wc-coupon-restrictions-validation.php
+++ b/includes/class-wc-coupon-restrictions-validation.php
@@ -96,7 +96,7 @@ class WC_Coupon_Restrictions_Validation {
 	 * Validates existing customer restriction.
 	 * Returns true if customer meets $coupon criteria.
 	 *
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @param string $email
 	 * @return boolean
 	 */
@@ -117,7 +117,7 @@ class WC_Coupon_Restrictions_Validation {
 	 * Validates role restrictions.
 	 * Returns true if customer meets $coupon criteria.
 	 *
-	 * @param object $coupon
+	 * @param WC_Coupon $coupon
 	 * @param string $email
 	 * @return boolean
 	 */

--- a/languages/woocommerce-coupon-restrictions.pot
+++ b/languages/woocommerce-coupon-restrictions.pot
@@ -1,36 +1,41 @@
-# Copyright (C) 2023 WooCommerce
+# Copyright (C) 2025 WooCommerce
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Coupon Restrictions 2.2.0\n"
+"Project-Id-Version: WooCommerce Coupon Restrictions 2.2.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-coupon-restrictions\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-03-09T19:55:29+00:00\n"
+"POT-Creation-Date: 2025-03-24T22:10:04+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.7.1\n"
+"X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: woocommerce-coupon-restrictions\n"
 
 #. Plugin Name of the plugin
+#: woocommerce-coupon-restrictions.php
 msgid "WooCommerce Coupon Restrictions"
 msgstr ""
 
 #. Plugin URI of the plugin
+#: woocommerce-coupon-restrictions.php
 msgid "http://woocommerce.com/products/woocommerce-coupon-restrictions/"
 msgstr ""
 
 #. Description of the plugin
+#: woocommerce-coupon-restrictions.php
 msgid "Create targeted coupons for new customers, user roles, countries or zip codes. Prevent coupon abuse with enhanced usage limits."
 msgstr ""
 
 #. Author of the plugin
+#: woocommerce-coupon-restrictions.php
 msgid "WooCommerce"
 msgstr ""
 
 #. Author URI of the plugin
+#: woocommerce-coupon-restrictions.php
 msgid "http://woocommerce.com/"
 msgstr ""
 
@@ -58,125 +63,125 @@ msgstr ""
 msgid "User role restriction"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:91
+#: includes/class-wc-coupon-restrictions-admin.php:92
 msgid "Guest (No User Account)"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:99
+#: includes/class-wc-coupon-restrictions-admin.php:100
 msgid "Choose roles&hellip;"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:99
+#: includes/class-wc-coupon-restrictions-admin.php:100
 msgid "Role"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:129
+#: includes/class-wc-coupon-restrictions-admin.php:130
 msgid "Use location restrictions"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:130
+#: includes/class-wc-coupon-restrictions-admin.php:131
 msgid "Display and enable location restriction options."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:141
+#: includes/class-wc-coupon-restrictions-admin.php:142
 msgid "Address for location restrictions"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:144
+#: includes/class-wc-coupon-restrictions-admin.php:145
 msgid "Shipping"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:145
+#: includes/class-wc-coupon-restrictions-admin.php:146
 msgid "Billing"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:152
+#: includes/class-wc-coupon-restrictions-admin.php:153
 msgid "Restrict to specific countries"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:170
+#: includes/class-wc-coupon-restrictions-admin.php:172
 msgid "Choose countries&hellip;"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:170
+#: includes/class-wc-coupon-restrictions-admin.php:172
 msgid "Country"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:187
+#: includes/class-wc-coupon-restrictions-admin.php:189
 msgid "Select any country that your store currently sells to."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:189
+#: includes/class-wc-coupon-restrictions-admin.php:191
 msgid "Adds all the countries that the store sells to in the restricted field."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:190
+#: includes/class-wc-coupon-restrictions-admin.php:192
 msgid "Add All Countries"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:192
+#: includes/class-wc-coupon-restrictions-admin.php:194
 msgid "Clears all restricted country selections."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:193
+#: includes/class-wc-coupon-restrictions-admin.php:195
 msgid "Clear"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:202
+#: includes/class-wc-coupon-restrictions-admin.php:204
 msgid "Restrict to specific states"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:203
+#: includes/class-wc-coupon-restrictions-admin.php:205
 msgid "Use the two digit state codes. Comma separate to specify multiple states."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:213
+#: includes/class-wc-coupon-restrictions-admin.php:215
 msgid "Restrict to specific zip codes"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:214
+#: includes/class-wc-coupon-restrictions-admin.php:216
 msgid "Comma separate to list multiple zip codes. Wildcards (*) can be used to match portions of zip codes."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:238
+#: includes/class-wc-coupon-restrictions-admin.php:240
 msgid "Enhanced Usage Limits"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:239
+#: includes/class-wc-coupon-restrictions-admin.php:241
 msgid "Enhanced usage limits should be set when the coupon is first created. WooCommerce will verify against previous orders made with a coupon that has enhanced usage restrictions."
 msgstr ""
 
 #. translators: %s: link to WooCommerce Coupon Restrictions documentation.
-#: includes/class-wc-coupon-restrictions-admin.php:241
+#: includes/class-wc-coupon-restrictions-admin.php:243
 msgid "Please read <a href=\"%1$s\">the documentation</a> for more information."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:252
+#: includes/class-wc-coupon-restrictions-admin.php:254
 msgid "Prevent similar emails"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:253
+#: includes/class-wc-coupon-restrictions-admin.php:255
 msgid "Many email services ignore periods and anything after a \"+\". Check this box to prevent customers from using a similar email address to exceed the usage limit per user."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:263
+#: includes/class-wc-coupon-restrictions-admin.php:265
 msgid "Usage limit per shipping address"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:264
-#: includes/class-wc-coupon-restrictions-admin.php:283
+#: includes/class-wc-coupon-restrictions-admin.php:266
+#: includes/class-wc-coupon-restrictions-admin.php:285
 msgid "Unlimited usage"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:265
+#: includes/class-wc-coupon-restrictions-admin.php:267
 msgid "How many times this coupon can be used with the same shipping address."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:282
+#: includes/class-wc-coupon-restrictions-admin.php:284
 msgid "Usage limit per IP address"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-admin.php:284
+#: includes/class-wc-coupon-restrictions-admin.php:286
 msgid "How many times this coupon can be used with the same IP address."
 msgstr ""
 
@@ -266,71 +271,71 @@ msgstr ""
 msgid "See how it works."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:203
+#: includes/class-wc-coupon-restrictions-onboarding.php:204
 msgid "Usage Restrictions"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:204
+#: includes/class-wc-coupon-restrictions-onboarding.php:205
 msgid "Coupon restrictions can be found in this panel."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:219
+#: includes/class-wc-coupon-restrictions-onboarding.php:220
 msgid "Customer Restrictions"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:220
+#: includes/class-wc-coupon-restrictions-onboarding.php:221
 msgid "You now have the option to restrict coupons to new customers or existing customers."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:221
+#: includes/class-wc-coupon-restrictions-onboarding.php:222
 msgid "Customers are considered \"new\" until they complete a purchase."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:236
+#: includes/class-wc-coupon-restrictions-onboarding.php:237
 msgid "Limit User Tip"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:237
+#: includes/class-wc-coupon-restrictions-onboarding.php:238
 msgid "If you are using a new customer restriction, you may also want to limit the coupon to 1 use."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:238
+#: includes/class-wc-coupon-restrictions-onboarding.php:239
 msgid "Payments can take a few minutes to process, and it is possible for a customer to place multiple orders in that time if a coupon does not have a 1 use limit."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:253
+#: includes/class-wc-coupon-restrictions-onboarding.php:254
 msgid "Role Restrictions"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:254
+#: includes/class-wc-coupon-restrictions-onboarding.php:255
 msgid "Coupons can be restricted to specific user roles. Customer must have an account for the coupon to apply."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:269
+#: includes/class-wc-coupon-restrictions-onboarding.php:270
 msgid "Location Restrictions"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:270
+#: includes/class-wc-coupon-restrictions-onboarding.php:271
 msgid "Checking this box displays options for country and/or zip code restrictions."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:280
+#: includes/class-wc-coupon-restrictions-onboarding.php:281
 msgid "Multiple Restrictions"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:281
+#: includes/class-wc-coupon-restrictions-onboarding.php:282
 msgid "If multiple coupon restrictions are set, the customer must meet all restrictions."
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:318
+#: includes/class-wc-coupon-restrictions-onboarding.php:320
 msgid "Dismiss"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:319
+#: includes/class-wc-coupon-restrictions-onboarding.php:321
 msgid "Next"
 msgstr ""
 
-#: includes/class-wc-coupon-restrictions-onboarding.php:320
+#: includes/class-wc-coupon-restrictions-onboarding.php:322
 msgid "Enjoy!"
 msgstr ""
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 -   WP requires at least: 6.2
 -   WP tested up to: 6.7
 -   WC requires at least: 8.6.1
--   WC tested up to: 9.5.2
+-   WC tested up to: 9.7.1
 -   Stable tag: 2.2.2
 -   License: [GPLv3 or later License](http://www.gnu.org/licenses/gpl-3.0.html)
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 -   WP tested up to: 6.7
 -   WC requires at least: 8.6.1
 -   WC tested up to: 9.7.1
--   Stable tag: 2.2.2
+-   Stable tag: 2.2.3
 -   License: [GPLv3 or later License](http://www.gnu.org/licenses/gpl-3.0.html)
 
 ## Description
@@ -62,6 +62,12 @@ To run the code checks from the command line run: `vendor/bin/phpcs`
 -   Run `composer make-pot` to update the translation file.
 
 ## Changelog
+
+**2.2.3 (2025-04-25)**
+
+-   Update: Declare compatibility with latest version of WooCommerce.
+-   Update: Improve docblock documentation.
+-   Update: Improve automated testing suite.
 
 **2.2.2 (2024-02-05)**
 

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ To run the code checks from the command line run: `vendor/bin/phpcs`
 **2.2.3 (2025-04-25)**
 
 -   Update: Declare compatibility with latest version of WooCommerce.
+-   Update: Fix deprecated call to is_coupon_valid.
 -   Update: Improve docblock documentation.
 -   Update: Improve automated testing suite.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,11 +3,11 @@
 Contributors: @downstairsdev
 Tags: woocommerce, coupon
 Requires at least: 6.2
-Tested up to: 6.7
+Tested up to: 6.7.2
 Requires PHP: 8.0
 Stable tag: 2.2.2
 License: GPLv3 or later License
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 WC requires at least: 8.6.1
-WC tested up to: 9.5.2
+WC tested up to: 9.7.1
 Woo: 3200406:6d7b7aa4f9565b8f7cbd2fe10d4f119a

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, coupon
 Requires at least: 6.2
 Tested up to: 6.7.2
 Requires PHP: 8.0
-Stable tag: 2.2.2
+Stable tag: 2.2.3
 License: GPLv3 or later License
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 WC requires at least: 8.6.1

--- a/woocommerce-coupon-restrictions.php
+++ b/woocommerce-coupon-restrictions.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Coupon Restrictions
  * Plugin URI: http://woocommerce.com/products/woocommerce-coupon-restrictions/
  * Description: Create targeted coupons for new customers, user roles, countries or zip codes. Prevent coupon abuse with enhanced usage limits.
- * Version: 2.2.2
+ * Version: 2.2.3
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
  * Developer: Devin Price

--- a/woocommerce-coupon-restrictions.php
+++ b/woocommerce-coupon-restrictions.php
@@ -13,7 +13,7 @@
  *
  * Woo: 3200406:6d7b7aa4f9565b8f7cbd2fe10d4f119a
  * WC requires at least: 8.6.1
- * WC tested up to: 9.5.2
+ * WC tested up to: 9.7.1
  *
  * Copyright: © 2015-2024 DevPress.
  * License: GNU General Public License v3.0


### PR DESCRIPTION
* Update: Declare compatibility with latest version of WooCommerce.
* Update: Fix deprecated call to is_coupon_valid.
* Update: Improve docblock documentation.
* Update: Improve automated testing suite.